### PR TITLE
fix yum repo name issue

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,7 +6,7 @@ class lldp::install {
 
   yumrepo { 'vbernat':
     ensure   => present,
-    name     => 'vbernat-lldp',
+    descr    => 'vbernat-lldp',
     baseurl  => "http://download.opensuse.org/repositories/home:/vbernat/CentOS_${::operatingsystemmajrelease}/",
     gpgcheck => 0,
     notify   => Exec['clean-cache'],


### PR DESCRIPTION
```
[flyinprogrammer@host ~]$ yum install vim
Loaded plugins: fastestmirror
Repository 'vbernat-lldp' is missing name in configuration, using id
```

https://docs.puppet.com/puppet/latest/reference/type.html#yumrepo-attribute-descr

this will produce a repo file like this:

```
[vbernat-lldp]
name=vbernat-lldp
baseurl=http://download.opensuse.org/repositories/home:/vbernat/CentOS_7/
gpgcheck=0
```

and get rid of that warning.
